### PR TITLE
Create default settings.json on first run; revert README settings section

### DIFF
--- a/core/system.py
+++ b/core/system.py
@@ -4,6 +4,28 @@ import platform
 from dataclasses import dataclass
 from typing import Dict, Any
 
+_DEFAULT_SETTINGS: Dict[str, Any] = {
+    "debug_mode": True,
+    "paths": {
+        "work_root": ".",
+        "osu_root_dirname": "Osu",
+        "backups_dirname": "Backups",
+        "backup_filename": "osu_main_system_backup.zip",
+        "temp_download_filename": "osu_temp.nupkg",
+        "extract_dirname": "osu_extract",
+    },
+    "github": {
+        "latest_release_api": "https://api.github.com/repos/ppy/osu/releases/latest",
+        "asset_name_suffix": "-full.nupkg",
+        "exclude_keywords": [
+            "linux",
+            "osx",
+            "mac",
+            "arm",
+        ],
+    },
+}
+
 @dataclass(frozen=True)
 class Paths:
     base_dir: str
@@ -25,6 +47,9 @@ def require_windows() -> None:
 
 def load_settings(settings_path: str) -> Dict[str, Any]:
     import json
+    if not os.path.exists(settings_path):
+        with open(settings_path, "w", encoding="utf-8") as f:
+            json.dump(_DEFAULT_SETTINGS, f, indent=2, ensure_ascii=False)
     with open(settings_path, "r", encoding="utf-8") as f:
         return json.load(f)
 

--- a/main.py
+++ b/main.py
@@ -65,9 +65,8 @@ def menu_manage_template(paths, debug_mode: bool) -> None:
             break
 
 def main() -> None:
-    require_windows()
-
     settings = load_settings(os.path.join(os.getcwd(), "settings.json"))
+    require_windows()
     debug_mode = bool(settings.get("debug_mode", True))
     paths = build_paths(settings)
 


### PR DESCRIPTION
### Motivation
- Ensure the application can start without a pre-existing `settings.json` by creating a sane default at first run.
- Remove the previously added README settings/API section to restore the README to its prior state.

### Description
- Add a `_DEFAULT_SETTINGS` dictionary in `core/system.py` with `debug_mode`, `paths`, and `github` defaults.
- Update `load_settings(settings_path)` in `core/system.py` to write `settings.json` with `_DEFAULT_SETTINGS` when the file is missing, then load it with `json.load`.
- Revert the README by removing the previously added `Einstellungen (settings.json)` / osu! API guidance section so `README.md` returns to its original content.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796c82f544832e946796a1f6d09289)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configuration files are now automatically initialized with default settings if missing, streamlining setup and preventing initialization errors on first launch.
  * Startup sequence adjusted so platform checks occur after settings are loaded, improving initialization reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->